### PR TITLE
Feature/visibility helpers

### DIFF
--- a/src/skin/frontend/base/default/css/linus/common.css
+++ b/src/skin/frontend/base/default/css/linus/common.css
@@ -7,3 +7,19 @@
  *
  * @author Dane MacMillan <work@danemacmillan.com>
  */
+
+/*
+For use with the common show/hide
+Hides and removes the element from the flow.
+*/
+.js-hidden {
+    display: none;
+}
+
+/*
+For use with the common show/hide
+Makes the element invisible, but does not remove from flow.
+*/
+.js-invisible {
+    visibility: hidden;
+}

--- a/src/skin/frontend/base/default/js/linus/common.js
+++ b/src/skin/frontend/base/default/js/linus/common.js
@@ -209,16 +209,16 @@ linus.common = linus.common || (function($)
      * improvement over the standard jQuery show/hide methods as it does not
      * create any inline css.
      *
-     * @param $selector
+     * @param selector
      */
-    function hide($selector)
+    function hide(selector)
     {
-        if (!$selector instanceof jQuery) {
-            $selector = $($selector);
+        if (!selector instanceof jQuery) {
+            selector = $(selector);
         }
 
-        if (!$selector.hasClass('js-hidden')) {
-            $selector.addClass('js-hidden');
+        if (!selector.hasClass('js-hidden')) {
+            selector.addClass('js-hidden');
         }
     }
 
@@ -229,32 +229,32 @@ linus.common = linus.common || (function($)
      * improvement over the standard jQuery show/hide methods as it does not
      * create any inline css.
      *
-     * @param $selector
+     * @param selector
      */
-    function invisible($selector)
+    function invisible(selector)
     {
-        if (!$selector instanceof jQuery) {
-            $selector = $($selector);
+        if (!selector instanceof jQuery) {
+            selector = $(selector);
         }
 
-        if (!$selector.hasClass('js-invisible')) {
-            $selector.addClass('js-invisible');
+        if (!selector.hasClass('js-invisible')) {
+            selector.addClass('js-invisible');
         }
     }
 
     /**
      * Shows an element that was hidden using the js-hidden or js-invisible classes.
      *
-     * @param $selector
+     * @param selector
      */
-    function show($selector)
+    function show(selector)
     {
-        if (!$selector instanceof jQuery) {
-            $selector = $($selector);
+        if (!selector instanceof jQuery) {
+            selector = $(selector);
         }
 
-        $selector.removeClass('js-hidden');
-        $selector.removeClass('js-invisible');
+        selector.removeClass('js-hidden');
+        selector.removeClass('js-invisible');
     }
 
     /**

--- a/src/skin/frontend/base/default/js/linus/common.js
+++ b/src/skin/frontend/base/default/js/linus/common.js
@@ -209,14 +209,16 @@ linus.common = linus.common || (function($)
      * improvement over the standard jQuery show/hide methods as it does not
      * create any inline css.
      *
-     * @param $selector a jQuery object to hide
+     * @param $selector
      */
     function hide($selector)
     {
-        if ($selector instanceof jQuery) {
-            if (!$selector.hasClass('js-hidden')) {
-                $selector.addClass('js-hidden');
-            }
+        if (!$selector instanceof jQuery) {
+            $selector = $($selector);
+        }
+
+        if (!$selector.hasClass('js-hidden')) {
+            $selector.addClass('js-hidden');
         }
     }
 
@@ -227,28 +229,32 @@ linus.common = linus.common || (function($)
      * improvement over the standard jQuery show/hide methods as it does not
      * create any inline css.
      *
-     * @param $selector a jQuery object to hide
+     * @param $selector
      */
     function invisible($selector)
     {
-        if ($selector instanceof jQuery) {
-            if (!$selector.hasClass('js-invisible')) {
-                $selector.addClass('js-invisible');
-            }
+        if (!$selector instanceof jQuery) {
+            $selector = $($selector);
+        }
+
+        if (!$selector.hasClass('js-invisible')) {
+            $selector.addClass('js-invisible');
         }
     }
 
     /**
      * Shows an element that was hidden using the js-hidden or js-invisible classes.
      *
-     * @param $selector a jQuery object to show
+     * @param $selector
      */
     function show($selector)
     {
-        if ($selector instanceof jQuery) {
-            $selector.removeClass('js-hidden');
-            $selector.removeClass('js-invisible');
+        if (!$selector instanceof jQuery) {
+            $selector = $($selector);
         }
+
+        $selector.removeClass('js-hidden');
+        $selector.removeClass('js-invisible');
     }
 
     /**

--- a/src/skin/frontend/base/default/js/linus/common.js
+++ b/src/skin/frontend/base/default/js/linus/common.js
@@ -203,6 +203,53 @@ linus.common = linus.common || (function($)
     }
 
     /**
+     * Hides the selected object, removing it from the page flow.
+     *
+     * This function applies the js-hidden class from common.css. This is an
+     * improvement over the standard jQuery show/hide methods as it does not
+     * create any inline css.
+     *
+     * @param $selector a jQuery object to hide
+     */
+    function hide($selector)
+    {
+        if ($selector instanceof jQuery) {
+            if (!$selector.hasClass('js-hidden')) {
+                $selector.addClass('js-hidden');
+            }
+        }
+    }
+
+    /**
+     * Hides the selected object, does not remove it from the page flow.
+     *
+     * This function applies the js-invisible class from common.css. This is an
+     * improvement over the standard jQuery show/hide methods as it does not
+     * create any inline css.
+     *
+     * @param $selector a jQuery object to hide
+     */
+    function invisible($selector)
+    {
+        if ($selector instanceof jQuery) {
+            if (!$selector.hasClass('js-invisible')) {
+                $selector.addClass('js-invisible');
+            }
+        }
+    }
+
+    /**
+     * Shows an element that was hidden using the js-hidden or js-invisible classes.
+     *
+     * @param $selector a jQuery object to show
+     */
+    function show($selector)
+    {
+        $selector.removeClass('js-hidden');
+        $selector.removeClass('js-invisible');
+    }
+
+    /**
      * Initialize class. Register for DOM ready.
      */
     (function __init() {
@@ -217,6 +264,9 @@ linus.common = linus.common || (function($)
     return {
         __: __,
         getCspData: getCspData,
+        hide: hide,
+        invisible: invisible,
+        show: show,
         translateAllTextIn: translateAllTextIn,
         use: use
     };

--- a/src/skin/frontend/base/default/js/linus/common.js
+++ b/src/skin/frontend/base/default/js/linus/common.js
@@ -245,8 +245,10 @@ linus.common = linus.common || (function($)
      */
     function show($selector)
     {
-        $selector.removeClass('js-hidden');
-        $selector.removeClass('js-invisible');
+        if ($selector instanceof jQuery) {
+            $selector.removeClass('js-hidden');
+            $selector.removeClass('js-invisible');
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds three functions to common.js to manipulate the visible and display of elements on a page using predefined classes in common.css.  The passed selector can be a string or a jQuery object.

`common.hide($selector)` : Hide the element by applying .js-hidden (display:none)
`common.invisible($selector)` : Hide the element by applying .js-invisible (visibility: none)
`common.show($selector)` : Remove both js-hidden and js-invisible if they exist.
